### PR TITLE
Made "Looks like you found a bug" window resizable

### DIFF
--- a/zim/gui/widgets.py
+++ b/zim/gui/widgets.py
@@ -3370,9 +3370,9 @@ class ErrorDialog(gtk.MessageDialog):
 			text = self.get_debug_text(exc_info)
 			window, textview = ScrolledTextView(text, monospace=True)
 			window.set_size_request(350, 200)
+			self.set_resizable(True)
 			self.vbox.add(window)
-			self.vbox.show_all()
-			# TODO use an expander here ?
+			self.vbox.show_all()			
 		else:
 			self.showing_trace = False # used in test
 			pass


### PR DESCRIPTION
Made the "Looks like you found a bug" dialog window resizable.
The default size is still the same because the default values also sort of serve as the minimum size that the window can be resized to.